### PR TITLE
Fix: Script permissions and Steam library detection (Issue #1)

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = optiscaler-universal
 	pkgdesc = Intelligent OptiScaler configuration tool for Linux gaming - automatically optimizes GPU settings
 	pkgver = 0.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ind4skylivey/0ptiscaler4linux
 	arch = any
 	license = MIT

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: ind4skylivey <https://github.com/ind4skylivey>
 pkgname=optiscaler-universal
 pkgver=0.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Intelligent OptiScaler configuration tool for Linux gaming - automatically optimizes GPU settings"
 arch=('any')
 url="https://github.com/ind4skylivey/0ptiscaler4linux"
@@ -30,6 +30,9 @@ package() {
     cp -r profiles "$pkgdir/usr/share/$pkgname/"
     cp -r scripts "$pkgdir/usr/share/$pkgname/"
     cp -r templates "$pkgdir/usr/share/$pkgname/"
+
+    # Set executable permissions on scripts
+    chmod +x "$pkgdir/usr/share/$pkgname/scripts/"*.sh
 
     # Install binaries directory structure
     install -dm755 "$pkgdir/usr/share/$pkgname/binaries"

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -39,6 +39,9 @@ package() {
     cp -r scripts "$pkgdir/usr/share/optiscaler-universal/"
     cp -r templates "$pkgdir/usr/share/optiscaler-universal/"
 
+    # Set executable permissions on scripts
+    chmod +x "$pkgdir/usr/share/optiscaler-universal/scripts/"*.sh
+
     # Install binaries directory structure
     install -dm755 "$pkgdir/usr/share/optiscaler-universal/binaries"
     cp -r binaries/* "$pkgdir/usr/share/optiscaler-universal/binaries/"

--- a/src/modules/game_detector.sh
+++ b/src/modules/game_detector.sh
@@ -22,6 +22,9 @@
 SCRIPT_ROOT="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 PROFILES_DIR="${PROFILES_DIR:-$SCRIPT_ROOT/config/games}"
 
+# Source required modules
+source "${SCRIPT_ROOT}/src/modules/steam_parser.sh"
+
 # SECURITY: Use user-owned directory for cache (not world-writable /tmp)
 OPTISCALER_DATA_DIR="${OPTISCALER_DATA_DIR:-$HOME/.optiscaler-universal}"
 CACHE_DIR="$OPTISCALER_DATA_DIR/cache"
@@ -214,9 +217,15 @@ discover_steam_libraries() {
 
     local lf
     while IFS= read -r lf; do
+        log_debug "Found libraryfolders.vdf: $lf"
         declare -a libs=()
-        parse_libraryfolders "$lf" libs || continue
+        if ! parse_libraryfolders "$lf" libs; then
+            log_warn "Failed to parse libraryfolders.vdf: $lf"
+            continue
+        fi
+        log_debug "Extracted ${#libs[@]} library path(s) from $lf"
         for lib_root in "${libs[@]}"; do
+            log_debug "Attempting to add library: $lib_root"
             _add_library_if_exists "$lib_root"
         done
     done < <(discover_libraryfolders_files)


### PR DESCRIPTION
## Summary

This PR fixes two critical issues reported in Issue #1 by user @hectormiguel1 on Arch Linux with AMD Radeon RX 7900 XTX.

### Problem 1: Scripts without executable permissions
- **Issue:** After installing via AUR (`yay -S optiscaler-universal`), scripts in `/usr/share/optiscaler-universal/scripts/` lacked execute permissions
- **Impact:** `optiscaler-install` command failed with "permission denied" error
- **Workaround:** Users had to manually run `sudo chmod +x /usr/share/optiscaler-universal/scripts/*.sh`

### Problem 2: Secondary Steam libraries not detected
- **Issue:** Only games in `~/.steam` were detected automatically
- **Impact:** Steam libraries configured on other partitions/disks were not recognized
- **Root cause:** `parse_libraryfolders()` function wasn't being sourced from steam_parser.sh module

---

## Changes

### Commit 1: `fix: set executable permissions on scripts during AUR install`
- ✅ Added `chmod +x` for all `.sh` files in scripts/ directory after copying
- ✅ Updated `pkgrel` from 1 to 2 to trigger package update in AUR
- ✅ Applied fix to both `PKGBUILD` and `PKGBUILD-git`
- ✅ Regenerated `.SRCINFO` with updated pkgrel

**Files modified:**
- `PKGBUILD` - Added chmod command after copying scripts
- `PKGBUILD-git` - Same fix for git version
- `.SRCINFO` - Updated pkgrel to 2

### Commit 2: `fix: improve Steam library detection for secondary paths`
- ✅ Added `source` directive to load `steam_parser.sh` module
- ✅ Added debug logging for each `libraryfolders.vdf` file found
- ✅ Added warning logs when VDF parsing fails
- ✅ Logs number of libraries extracted from each VDF file
- ✅ Logs each library path being added for better troubleshooting

**Files modified:**
- `src/modules/game_detector.sh` - Added module import and enhanced logging

---

## Testing

### Test 1: Script Permissions
```bash
# After installing with yay/paru
optiscaler-install  # Should work without manual chmod
ls -l /usr/share/optiscaler-universal/scripts/*.sh  # Should show -rwxr-xr-x
```

### Test 2: Steam Library Detection
```bash
# Enable debug logging
export LOG_LEVEL=DEBUG

# Run game detection
optiscaler-diagnose --detect-games

# Expected output:
# - Found libraryfolders.vdf: <path>
# - Extracted N library path(s) from <path>
# - Attempting to add library: <path>
# - Found X Steam library(ies)
```

### Test 3: Secondary Libraries
Users with Steam libraries on separate drives should now see:
- All configured libraries detected automatically
- No need to set `OPTISCALER_STEAM_HINTS` environment variable
- Clear debug output showing detection process

---

## Verification

- ✅ All bash syntax checks pass (`bash -n` on all modified files)
- ✅ Changes maintain backward compatibility
- ✅ No modifications to game detection logic
- ✅ Enhanced logging uses existing `log_debug`/`log_warn` functions
- ✅ Both PKGBUILD files updated consistently
- ✅ pkgrel incremented to trigger AUR update

---

## Impact

This PR will:
1. **Eliminate** the need for users to manually chmod scripts after installation
2. **Enable** automatic detection of Steam libraries on any mounted partition
3. **Improve** troubleshooting with detailed debug logging
4. **Maintain** full backward compatibility with existing installations

Fixes #1